### PR TITLE
[TS-STEP-05] 클래스와 Mixin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,14 @@ const store : Store = {
   currentPage: 1,
   feeds : new Map()
 };
+class Api {
+  url: string;
+  ajax: XMLHttpRequest;
+  constructor(url:string) {
+    this.url = url;
+    this.ajax = new XMLHttpRequest();
+  }
+}
 const GET_DATA_API = <AjaxResponse>( url : string ) : AjaxResponse=> {
   ajax.open('GET', url, false);
   ajax.send();

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,24 @@ class Api {
     this.url = url;
     this.ajax = new XMLHttpRequest();
   }
+  getRequest<AjaxResponse>(): AjaxResponse {
+    this.ajax.open('GET', this.url, false);
+    this.ajax.send();
+    return JSON.parse(ajax.response)
+  }
+}
+
+class NewsFeedApi extends Api {
+  getData(): NewsFeed[] {
+    return this.getRequest<NewsFeed[]>();
+  }
+}
+
+
+class NewsDetailApi extends Api {
+  getData(): NewsDetail {
+    return this.getRequest<NewsDetail>();
+  }
 }
 const GET_DATA_API = <AjaxResponse>( url : string ) : AjaxResponse=> {
   ajax.open('GET', url, false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,10 +43,10 @@ class Api {
     this.url = url;
     this.ajax = new XMLHttpRequest();
   }
-  getRequest<AjaxResponse>(): AjaxResponse {
+  protected getRequest<AjaxResponse>(): AjaxResponse {
     this.ajax.open('GET', this.url, false);
     this.ajax.send();
-    return JSON.parse(ajax.response)
+    return JSON.parse(this.ajax.response)
   }
 }
 
@@ -106,7 +106,8 @@ function makeComment(comments :NewsComment[]) : string {
   return commentString.join('');
 }
 
-function newsFeeds() :void {
+function newsFeeds(): void {
+  const api = new NewsFeedApi(NEWS_URL.replace('@currentPage', String(store.currentPage)))
   let template = `
   <div class="bg-gray-600 min-h-screen">
   <div class="bg-white text-xl">
@@ -135,7 +136,7 @@ function newsFeeds() :void {
   if (store.feeds.has(store.currentPage)) {
     newsFeed = store.feeds.get(store.currentPage)??[]
   } else {
-    newsFeed = make_read_feeds(GET_DATA_API<NewsFeed[]>(NEWS_URL.replace('@currentPage', String(store.currentPage))));
+    newsFeed = make_read_feeds(api.getData());
     store.feeds.set(store.currentPage,newsFeed)
   }
   const newsTemplate = newsFeed.map(item => `
@@ -163,7 +164,8 @@ function newsFeeds() :void {
 }
 function newsDetail() :void {
   const id = location.hash.substr(7);
-  const newsContent = GET_DATA_API<NewsDetail>(CONTENT_URL.replace('@id', id));
+  const api = new NewsDetailApi(CONTENT_URL.replace('@id', id))
+  const newsContent = api.getData();
   const current_newsFeed : NewsFeed[] = store.feeds.get(store.currentPage)??[];
   current_newsFeed.forEach((feed) => {
     if (feed.id === Number(id)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,11 +62,6 @@ class NewsDetailApi extends Api {
     return this.getRequest<NewsDetail>();
   }
 }
-const GET_DATA_API = <AjaxResponse>( url : string ) : AjaxResponse=> {
-  ajax.open('GET', url, false);
-  ajax.send();
-  return JSON.parse(ajax.response);
-}
 
 const make_read_feeds = (feeds : NewsFeed[]) : NewsFeed[]=> {
   return feeds.map((feed) => {


### PR DESCRIPTION
1. 클래스를 통해 상속을 받아서 분리를 할 수 있다.
2. 클래스를 통한 extends도 있지만, 자바스크립트는 다중상속을 지원하지 않으므로, 다중상속을 위해, Mixin을 쓰는경우가 있다.
3. Mixin은 별도의 함수를 통해서 구현을 해야한다.
4. Mixin을 통해 구현을 했을시, typescript가 에러를 반환하는데, 그 이유는 우리는 함수를 통해 상속을 받았기 때문에, typescirpt 내에서는 이 사실까지는 알지 못한다. 그러므로 interface를 통해 상속받은 클래스가 상속을 받았다고 표현을 해줘야한다.